### PR TITLE
Remove callback module from application file

### DIFF
--- a/src/strftimerl.app.src
+++ b/src/strftimerl.app.src
@@ -9,6 +9,5 @@
     kernel,
     stdlib
   ]},
-  {mod, {strftimerl, []}},
   {env, []}
 ]}.


### PR DESCRIPTION
Hi,

I have a problem using this library with Elixir on production. I have to specify it in `mix.exs` in applications:

``` elixir
def application do
  [mod: {MyApp, []},
   applications: [..., :strftimerl]]
end
```

otherwise it's not included in build and I can't use it. But after I specify it, I can't start my app. I receive this error:

```
Erlang/OTP 19 [erts-8.0.2] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

*** ERROR: Shell process terminated! (^G to start new job) ***
{"Kernel pid terminated",application_controller,"{application_start_failure,strftimerl,{bad_return,{{strftimerl,start,[normal,[]]},{'EXIT',{undef,[{strftimerl,start,[normal,[]],[]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,273}]}]}}}}}"}

Crash dump is being written to: erl_crash.dump...done
Kernel pid terminated (application_controller) ({application_start_failure,strftimerl,{bad_return,{{strftimerl,start,[normal,[]]},{'EXIT',{undef,[{strftimerl,start,[normal,[]],[]},{application_master,
```

I don't have any experience creating Erlang libraries, but from what I understand, specifying `{mod, {strftimerl, []}}` implicates that `:strftimerl:start` will be called when starting an OTP app.

Here's [LYSE fragment I found about it](http://learnyousomeerlang.com/building-otp-applications):

>   **{mod, {CallbackMod, Args}}**
> 
>  Defines a callback module for the application, using the application behaviour (which we will see in the next section). This tells OTP that when starting your application, it should call CallbackMod:start(normal, Args). This function's return value will be used when OTP will call CallbackMod:stop(StartReturn) when stopping your application. People will tend to name CallbackMod after their application.

I've researched other Erlang libraries available in Hex and found [yamerl](https://hex.pm/packages/yamerl) which [specifies `mod`](https://github.com/yakaz/yamerl/blob/master/src/yamerl.app.src#L17) and [exports `start` and `stop` functions](https://github.com/yakaz/yamerl/blob/master/src/yamerl_app.erl#L48).

On the other hand, [erlsom](https://hex.pm/packages/erlsom) [doesn't specify it](https://github.com/willemdj/erlsom/blob/master/src/erlsom.app.src) and works correctly with my application on production.

I also found [blogpost about creating Elixir libraries with relevant comment from Saša Jurić](https://www.amberbit.com/blog/2016/5/10/creating-elixir-libraries-as-otp-applications/#comment-2677186959). Please let me know whether this makes sense, I might be mistaken in any step.
